### PR TITLE
Add Fly.io deployment configuration

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -1,0 +1,33 @@
+app = "mcp-fema-usar"
+primary_region = "iad"
+
+[build]
+  builder = "paketobuildpacks/builder-jammy-base:latest"
+
+[env]
+  PORT = "8000"
+
+[processes]
+  app = "python server.py"
+
+[[services]]
+  internal_port = 8000
+  protocol = "tcp"
+  processes = ["app"]
+
+  [[services.ports]]
+    handlers = ["http"]
+    port = 80
+
+  [[services.ports]]
+    handlers = ["tls", "http"]
+    port = 443
+
+  [[services.tcp_checks]]
+    interval = "15s"
+    timeout = "2s"
+
+  [[services.http_checks]]
+    path = "/"
+    interval = "15s"
+    timeout = "2s"


### PR DESCRIPTION
## Summary
- add `fly.toml` with basic Fly.io settings

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_6862fdd7cf288328b7b9bcf993644b4f