### PR TITLE
Add Dockerfile for fly.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+# Prevent Python from writing pyc files and buffering stdout/stderr
+ENV PYTHONUNBUFFERED=1
+
+# Set the working directory
+WORKDIR /app
+
+# Install runtime dependencies
+RUN pip install --no-cache-dir fastmcp
+
+# Copy application files
+COPY server.py ./
+COPY resources ./resources
+
+# Expose the port used by the application
+EXPOSE 8000
+
+# Command to run the application
+CMD ["python", "server.py"]


### PR DESCRIPTION
## Summary
- add a simple Dockerfile to run the FastMCP server

## Testing
- `python -m py_compile server.py`


------
https://chatgpt.com/codex/tasks/task_e_6862ff6253088328b9f861267eb1319e