### PR TITLE
Add tests and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,19 @@
+name: Run Tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install fastmcp fastapi pytest
+      - name: Run tests
+        run: pytest -q

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,0 +1,35 @@
+import json
+import sys
+from pathlib import Path
+from fastapi.testclient import TestClient
+
+# Ensure repository root is in Python path when running via `pytest`
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import server
+
+client = TestClient(server.app)
+
+
+def test_list_forms():
+    response = client.get('/ics_forms')
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == len(server.ICS_FORMS)
+    # check that first item matches
+    assert data[0]['id'] == server.ICS_FORMS[0].id
+
+
+def test_get_form():
+    form = server.ICS_FORMS[0]
+    response = client.get(f'/ics_forms/{form.id}')
+    assert response.status_code == 200
+    data = response.json()
+    assert data['id'] == form.id
+    assert data['name'] == form.name
+
+
+def test_get_form_not_found():
+    response = client.get('/ics_forms/unknown')
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- add pytest-based test suite for the FastAPI server
- run tests automatically via GitHub Actions on pushes and PRs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686300d25bf88328a79eb559092e6ad1