### PR TITLE
Fix missing FastAPI runtime dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PYTHONUNBUFFERED=1
 WORKDIR /app
 
 # Install runtime dependencies
-RUN pip install --no-cache-dir fastmcp
+RUN pip install --no-cache-dir fastmcp fastapi
 
 # Copy application files
 COPY server.py ./

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ A FastMCP server providing FEMA Urban Search and Rescue (USAR) workers with acce
 ## Requirements
 * Python 3.12+
 * `fastmcp`
+* `fastapi`
 
 Install dependencies:
 
 ```bash
-pip install fastmcp
+pip install fastmcp fastapi
 ```
 
 ## Running


### PR DESCRIPTION
## Summary
- install FastAPI in the Docker image
- mention FastAPI in README install instructions

## Testing
- `pip show fastapi`


------
https://chatgpt.com/codex/tasks/task_e_686314b5dfb483289ce67e8072553e4d