### PR TITLE
Add additional open datasets and dataset tests

### DIFF
--- a/resources/open_datasets.json
+++ b/resources/open_datasets.json
@@ -16,5 +16,29 @@
     "name": "FEMA NIMS ICS Forms",
     "description": "Official Incident Command System forms in PDF format.",
     "url": "https://www.fema.gov/emergency-managers/nims/components/incident-command-system"
+  },
+  {
+    "id": "sarcop_resources",
+    "name": "SARCOP Reference Materials",
+    "description": "Documents and guides hosted on the SARCOP site for search and rescue operations.",
+    "url": "https://sarcop.org"
+  },
+  {
+    "id": "responsesystem_org",
+    "name": "ResponseSystem.org Library",
+    "description": "Reference library and SharePoint for incident response coordination.",
+    "url": "https://responsesystem.org"
+  },
+  {
+    "id": "nifog",
+    "name": "National Interoperability Field Operations Guide (NIFOG)",
+    "description": "Official DHS guide for communications interoperability.",
+    "url": "https://www.dhs.gov/safecom/nifog"
+  },
+  {
+    "id": "caloes_ifog",
+    "name": "CAL OES iFOG / FIRESCOPE",
+    "description": "California version of the Interoperability Field Operations Guide.",
+    "url": "https://firescope.org/ifog"
   }
 ]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -33,3 +33,26 @@ def test_get_form():
 def test_get_form_not_found():
     response = client.get('/ics_forms/unknown')
     assert response.status_code == 404
+
+
+def test_list_datasets():
+    response = client.get('/datasets')
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == len(server.OPEN_DATASETS)
+    assert data[0]['id'] == server.OPEN_DATASETS[0].id
+
+
+def test_get_dataset():
+    dataset = server.OPEN_DATASETS[0]
+    response = client.get(f'/datasets/{dataset.id}')
+    assert response.status_code == 200
+    data = response.json()
+    assert data['id'] == dataset.id
+    assert data['name'] == dataset.name
+
+
+def test_get_dataset_not_found():
+    response = client.get('/datasets/unknown')
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary
- extend `open_datasets.json` with new reference materials
- add tests covering dataset endpoints

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68631aeb67bc8328a382001bf45c54e1